### PR TITLE
Update clevo_acpi.c for Linux 6.10

### DIFF
--- a/src/clevo_acpi.c
+++ b/src/clevo_acpi.c
@@ -186,7 +186,9 @@ static const struct acpi_device_id clevo_acpi_device_ids[] = {
 static struct acpi_driver clevo_acpi_driver = {
 	.name = DRIVER_NAME,
 	.class = DRIVER_NAME,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0)
 	.owner = THIS_MODULE,
+#endif
 	.ids = clevo_acpi_device_ids,
 	.flags = ACPI_DRIVER_ALL_NOTIFY_EVENTS,
 	.ops = {

--- a/src/clevo_keyboard.h
+++ b/src/clevo_keyboard.h
@@ -19,6 +19,7 @@
 #ifndef CLEVO_KEYBOARD_H
 #define CLEVO_KEYBOARD_H
 
+#include <linux/version.h>
 #include "tuxedo_keyboard_common.h"
 #include "clevo_interfaces.h"
 #include "clevo_leds.h"
@@ -358,12 +359,20 @@ static void clevo_keyboard_remove_device_interface(struct platform_device *dev)
 	}
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int clevo_keyboard_remove(struct platform_device *dev)
 {
 	clevo_keyboard_remove_device_interface(dev);
 	clevo_leds_remove(dev);
 	return 0;
 }
+#else
+static void clevo_keyboard_remove(struct platform_device *dev)
+{
+	clevo_keyboard_remove_device_interface(dev);
+	clevo_leds_remove(dev);
+}
+#endif
 
 static int clevo_keyboard_suspend(struct platform_device *dev, pm_message_t state)
 {

--- a/src/uniwill_keyboard.h
+++ b/src/uniwill_keyboard.h
@@ -1214,7 +1214,11 @@ static int uniwill_keyboard_probe(struct platform_device *dev)
 	return 0;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int uniwill_keyboard_remove(struct platform_device *dev)
+#else
+static void uniwill_keyboard_remove(struct platform_device *dev)
+#endif
 {
 	if (uw_charging_prio_loaded)
 		sysfs_remove_group(&dev->dev.kobj, &uw_charging_prio_attr_group);
@@ -1238,8 +1242,9 @@ static int uniwill_keyboard_remove(struct platform_device *dev)
 
 	// Disable manual mode
 	uniwill_write_ec_ram(0x0741, 0x00);
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 	return 0;
+#endif
 }
 
 static int uniwill_keyboard_suspend(struct platform_device *dev, pm_message_t state)


### PR DESCRIPTION
The upstream kernel removed the owner field of `struct acpi_driver` in version 6.10 (https://github.com/torvalds/linux/commit/cc85f9c05bba23eb525497b42ac5b74801ccbd87). Fix the resulting compile error by removing the now-obsolete assignment to `.owner` in kernel 6.10 and later.